### PR TITLE
Improve testsuite

### DIFF
--- a/test/test_binary_file_search.py
+++ b/test/test_binary_file_search.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 from binary_file_search.BinaryFileSearch import BinaryFileSearch
 
@@ -107,3 +108,7 @@ class TestBinaryFileSearch_IntModeSecondColumn(TestCase):
 
     def test_multiple_lines(self):
         self.assertLess(1, len(self.bfs.search(40)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_binary_file_search.py
+++ b/test/test_binary_file_search.py
@@ -40,7 +40,7 @@ class TestBinaryFileSearch_StrMode(TestCase):
         self.assertEqual(1, len(self.bfs.search('aaa')))
 
     def test_multiple_lines(self):
-        self.assertEquals(2, len(self.bfs.search('bA')))
+        self.assertEqual(2, len(self.bfs.search('bA')))
 
     def test_multiple_searches(self):
         self.assertEqual([['bA', 'fourth_1'], ['bA', 'fourth_2']], self.bfs.search(query='bA'))


### PR DESCRIPTION
I would like to propose some improvements to the testsuite, eventually allowing it to run via python test runners like 'python -m unittest'.

This PR contains two changes:
* It replaces an obsolete method that no longer works in Python 3.12 (assertEquals, it was just an alias for assertEqual).
* It adds a call to the unittest main function to allow manually running the test.

Furthermore, I would like to propose to make test_binary_file_search.py path independent so you can run it from the main directory, and convert compare_bash_sort_with_python.py to python's unittest framework. But I thought I'd submit the changes in smaller pieces, and I think the above two should be not very controversial.